### PR TITLE
add profile_csv input for 1d grid and bathy workflows

### DIFF
--- a/oceanicospy/models/xbeachpy/preprocess/bathymaker.py
+++ b/oceanicospy/models/xbeachpy/preprocess/bathymaker.py
@@ -21,7 +21,12 @@ class BathyMaker:
        - Writes a .dep file (single column of depths) and an optional CSV
          with the extracted profile.
 
-    2) 2D mode (xyz2asc):
+    2) 1D mode (file-based):
+       - Reads a 2-column (x, z) profile from file.
+       - Interpolates z to match a .grd file.
+       - Writes corresponding .dep file.
+
+    3) 2D mode (xyz2asc):
        - Converts bathymetry data from XYZ format to ESRI ASCII Grid format.
 
     Parameters
@@ -315,6 +320,69 @@ class BathyMaker:
         print(f"Profile CSV written to: {profile_csv_path}")
 
         return profile_df
+    
+    def build_1d_profile_from_file(
+        self,
+        profile_filename: str,
+        x_grd_name: str = "x_profile.grd",
+        dep_name: str | None = None,
+    ) -> pd.DataFrame:
+        """
+        Interpolates a (x, z) profile from a text file to match the XBeach .grd,
+        and saves a .dep file in the run folder.
+
+        Parameters
+        ----------
+        profile_filename : str
+            Name of the 2-column text file (x, z) located in input folder.
+        x_grd_name : str, optional
+            Name of the .grd file located in the run folder.
+        dep_name : str, optional
+            Output .dep file name. Default is self.filename.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with 'x_grd' and 'z_interp' columns.
+        """
+
+        input_folder = self.init.dict_folders["input"]
+        run_folder = self.init.dict_folders["run"]
+
+        profile_path = os.path.join(input_folder, profile_filename)
+        x_grd_path = os.path.join(run_folder, x_grd_name)
+
+        if not os.path.isfile(profile_path):
+            raise FileNotFoundError(f"Profile file not found: {profile_path}")
+        if not os.path.isfile(x_grd_path):
+            raise FileNotFoundError(f"GRD file not found: {x_grd_path}")
+
+        # Read file (x,z) 
+        profile = pd.read_csv(profile_path, sep=",", header=0)  
+        profile.columns = ["x", "z"]  
+
+        profile["x"] = pd.to_numeric(profile["x"], errors="coerce")
+        profile["z"] = pd.to_numeric(profile["z"], errors="coerce")
+        profile = profile.dropna()
+
+        profile = profile.sort_values("x")
+
+
+        # Read x_profile.grd
+        x_grd = np.loadtxt(x_grd_path).astype(float).ravel()
+
+        # Interpolation
+        z_interp = np.interp(x_grd, profile["x"], profile["z"])
+
+        # Save as .dep file
+        if dep_name is None:
+            dep_name = self.filename
+        dep_path = os.path.join(run_folder, dep_name)
+        np.savetxt(dep_path, z_interp.reshape(-1, 1), fmt="%.3f")
+        print(f"Interpolated 1D .dep written to: {dep_path}")
+
+        return pd.DataFrame({"x_grd": x_grd, "z_interp": z_interp})
+        
 
     # ------------------------------------------------------------------
     # 2D mode 

--- a/oceanicospy/models/xbeachpy/preprocess/gridmaker.py
+++ b/oceanicospy/models/xbeachpy/preprocess/gridmaker.py
@@ -29,6 +29,7 @@ class GridMaker():
         end_xy=None,
         auto_extend=True,
         as_n_cells=False,
+        profile_csv=None,
         *args,
         **kwargs
         ):
@@ -69,7 +70,7 @@ class GridMaker():
 
         self.auto_extend = auto_extend
         self.as_n_cells = as_n_cells
-
+        self.profile_csv = profile_csv 
         # Store planar coordinates
         self.start_xy = np.array(start_xy, dtype=float) if start_xy is not None else None
         self.end_xy = np.array(end_xy, dtype=float) if end_xy is not None else None
@@ -615,6 +616,19 @@ class GridMaker():
         # 1D CASE
         # ======================================================================
         if str(dims) == "1":
+            if self.profile_csv is None:
+                raise ValueError("No planar coordinates provided and no 'profile_csv' specified.")
+
+            input_folder = Path(self.init.dict_folders["input"])
+            profile_path = input_folder / self.profile_csv
+
+            if not profile_path.exists():
+                raise FileNotFoundError(f"Specified profile file '{self.profile_csv}' not found in input folder.")
+
+            arr = np.loadtxt(profile_path, delimiter=",", skiprows=1)
+            if arr.shape[1] < 2:
+                raise ValueError(f"File '{self.profile_csv}' must contain at least two columns (x, z).")
+
             # --------------------------------------------------------------
             # 1D profile grid
             # --------------------------------------------------------------
@@ -665,11 +679,21 @@ class GridMaker():
                 }
 
             else:
-                # Classic 1-D profile in x only (no planar coordinates)
+                # Load the x,z profile to infer the end_x_point
+                arr = np.loadtxt(profile_path, delimiter=",", skiprows=1)
+                x_values = arr[:, 0]
+
+                x_values = arr[:, 0]
+                if x_values.size < 2:
+                    raise ValueError("Profile file must contain at least two x values.")
+
+                # Estimate length from x[0] to x[-1]
+                x0 = float(x_values[0])
+                x1 = float(x_values[-1])
+                length = abs(x1 - x0)
+
                 if getattr(self, "end_x_point", None) is None:
-                    raise ValueError(
-                        "For 1D grid without planar coordinates you must provide 'end_x_point'."
-                    )
+                    self.end_x_point = length
 
                 start_x_point = 0.0
 
@@ -681,6 +705,7 @@ class GridMaker():
                     as_n_cells=as_n_cells_flag,
                 )
                 y_points = np.zeros_like(x_points)
+
 
                 grid_dict = {
                     "xfilepath": "x_profile.grd",


### PR DESCRIPTION
Adds support for reading 1D profile data from a profile_csv file for both grid and bathymetry workflows in the XBeach preprocess step. Falls back to start_xy and end_xy planar coordinates if the CSV is not provided.